### PR TITLE
Better nameid errors

### DIFF
--- a/src/SURFnet.Authentication.Adfs.Plugin/Adapter.cs
+++ b/src/SURFnet.Authentication.Adfs.Plugin/Adapter.cs
@@ -309,6 +309,7 @@ namespace SURFnet.Authentication.Adfs.Plugin
 
                 if (!StepUpConfig.Current.GetNameID.TryGetNameIDValue(identityClaim, out NameIDValueResult nameIDValueResult))
                 {
+                    LogService.Log.ErrorFormat("Could not determine NameID for user with identityclaim '{0}'", identityClaim.Value);
                     throw new NotSupportedException();
                 }
 

--- a/src/SURFnet.Authentication.Adfs.Plugin/Adapter.cs
+++ b/src/SURFnet.Authentication.Adfs.Plugin/Adapter.cs
@@ -310,7 +310,11 @@ namespace SURFnet.Authentication.Adfs.Plugin
                 if (!StepUpConfig.Current.GetNameID.TryGetNameIDValue(identityClaim, out NameIDValueResult nameIDValueResult))
                 {
                     LogService.Log.ErrorFormat("Could not determine NameID for user with identityclaim '{0}'", identityClaim.Value);
-                    throw new NotSupportedException();
+                    return new AuthFailedForm(
+                        false,
+                        ErrorMessageValues.MissingAccountInfoResourcerId,
+                        context.ContextId,
+                        context.ActivityId);
                 }
 
                 var requestId = $"_{context.ContextId}";

--- a/src/SURFnet.Authentication.Adfs.Plugin/NameIdConfiguration/GetNameIDBase.cs
+++ b/src/SURFnet.Authentication.Adfs.Plugin/NameIdConfiguration/GetNameIDBase.cs
@@ -173,9 +173,11 @@ namespace SURFnet.Authentication.Adfs.Plugin.NameIdConfiguration
         /// <inheritdoc />
         public virtual bool TryGetNameIDValue(Claim identityClaim, out NameIDValueResult nameIDValueResult)
         {
+            this.Log.Debug("Enter GetNameIDBase::TryGetNameIDValue()");
             var userAttributes = this.GetAttributes(identityClaim);
             if (userAttributes.UserObject != null)
             {
+                this.Log.Debug("Found user in AD");
                 try
                 {
                     var nameId = this.ComposeNameID(identityClaim, userAttributes.UserObject);
@@ -185,6 +187,8 @@ namespace SURFnet.Authentication.Adfs.Plugin.NameIdConfiguration
                             nameId,
                             userAttributes.UserObject.Name,
                             userAttributes.UserGroups);
+
+                        this.Log.Debug("Leave GetNameIDBase::TryGetNameIDValue()");
                         return true;
                     }
                 }
@@ -199,6 +203,7 @@ namespace SURFnet.Authentication.Adfs.Plugin.NameIdConfiguration
             }
 
             nameIDValueResult = NameIDValueResult.CreateEmpty();
+            this.Log.Debug("Leave GetNameIDBase::TryGetNameIDValue()");
             return false;
         }
 

--- a/src/SURFnet.Authentication.Adfs.Plugin/NameIdConfiguration/UserIDFromADAttr.cs
+++ b/src/SURFnet.Authentication.Adfs.Plugin/NameIdConfiguration/UserIDFromADAttr.cs
@@ -43,13 +43,22 @@ namespace SURFnet.Authentication.Adfs.Plugin.NameIdConfiguration
 
         protected override string ComposeNameID(Claim claim, DirectoryEntry de)
         {
+            this.Log.Debug("Enter UserIDFromADAttr::ComposeNameID()");
             string nameID = null;
-            string uid = de.Properties[_activeDirectoryUserIdAttribute]?.Value.ToString();
-            if (uid != null)
+            //string uid = de.Properties[_activeDirectoryUserIdAttribute]?.Value.ToString();
+            PropertyValueCollection pvc = de.Properties[_activeDirectoryUserIdAttribute];
+            if ((pvc == null) || (pvc.Value == null))
             {
-                nameID = BuildNameID(_schacHomeOrganization, uid);
+                this.Log.ErrorFormat("User '{0}' is missing the '{1}' AD attribute", claim.Value, _activeDirectoryUserIdAttribute);
+                return null;
             }
 
+            string uid = pvc.Value.ToString();
+            this.Log.DebugFormat("uid = {0}", uid);
+
+            nameID = BuildNameID(_schacHomeOrganization, uid);
+
+            this.Log.Debug("Leave UserIDFromADAttr::ComposeNameID()");
             return nameID;
         }
     }

--- a/src/SURFnet.Authentication.Adfs.Plugin/Setup/Common/ErrorMessageValues.cs
+++ b/src/SURFnet.Authentication.Adfs.Plugin/Setup/Common/ErrorMessageValues.cs
@@ -11,5 +11,10 @@
         /// The default verification failed resourcer identifier.
         /// </summary>
         public const string DefaultVerificationFailedResourcerId = "ERROR_0001";
+
+        /// <summary>
+        /// The default verification failed resourcer identifier.
+        /// </summary>
+        public const string MissingAccountInfoResourcerId = "ERROR_0003";
     }
 }


### PR DESCRIPTION
Fix the case where in the default NameID creation method (UserIDFromAD), the AD attribute that was read to get the user's uid did not have a value would cause a NullReferenceException. Now an error is logged containing the user identity and the name of the attibute that is missing.

Previously, when any NameID creation failed, a NotSupportedException would be thrown. Now an additional error is logged stating that the NameID could not be detimined that included the user's identity claim.

Additionally show a "your account is missing information" error message when NameID creation fails. For custom NameID creation methods this might not be correct, but I thing that have a distinct error message of the generic one, without having to change the interface is an improvement.