### PR TITLE
Update user facing error messages

### DIFF
--- a/src/SURFnet.Authentication.Adfs.Plugin/Resources/Labels.1033.json
+++ b/src/SURFnet.Authentication.Adfs.Plugin/Resources/Labels.1033.json
@@ -1,16 +1,16 @@
 {
-  "ERROR_0000": "An unexpected error occured. Please try again. Please contact your IT admin and provide the following details: ContextId '{0}', ActivityId '{1}'",
-  "ERROR_0001": "Verification failed. Please contact your IT admin and provide the following details: ContextId '{0}', ActivityId '{1}'",
-  "ERROR_0002": "The StepUp configuration is incorrect. Please contact your IT admin and provide the following details: ContextId '{0}', ActivityId '{1}'",
-  "ERROR_0003": "Your account is not configured for MFA in the Active Directory . Please contact your IT admin and provide the following details: ContextId '{0}', ActivityId '{1}'",
-  "AuthFailedFormTitle": "Authentication failed",
-  "SamlAuthFailedFormTitle": "Authentication failed",
+  "ERROR_0000": "An unexpected error occured. Please try again. For more information please contact your local ICT-servicedesk and provide the details below.: ContextId '{0}', ActivityId '{1}'",
+  "ERROR_0001": "The additional authentication failed. For more information please contact your local ICT-servicedesk and provide the details below.: ContextId '{0}', ActivityId '{1}'",
+  "ERROR_0002": "The configuration of this MFA extension is not correct. Please contact your local ICT-servicedesk and provide the details below.: ContextId '{0}', ActivityId '{1}'",
+  "ERROR_0003": "Your account is missing information required for the additional authentication. For more information please contact your local ICT-servicedesk and provide the details below.: ContextId '{0}', ActivityId '{1}'",
+  "AuthFailedFormTitle": "Additional authentication failed",
+  "SamlAuthFailedFormTitle": "Additional authentication failed",
   "NoJavascript": "You have disabled Javascript. Please enable it to continue.",
   "OneMomentPlease": "One moment please...",
   "Working": "Working...",
-  "Description": "SURFNet Second Factor Authentication",
-  "FriendlyName": "SURFNet Second Factor Authentication",
-  "ERROR_SAML_Default": "Saml Error. Please contact your IT admin and provide the details below.",
-  "ERROR_SAML_AuthnFailed": "Saml AuthnFailed Error. Please contact your IT admin and provide the details below.",
-  "ERROR_SAML_NoAuthnContext": "Saml AuthnFailed Error. Please contact your IT admin and provide the details below."
+  "Description": "SURF Second Factor Authentication",
+  "FriendlyName": "SURF Second Factor Authentication",
+  "ERROR_SAML_Default": "The additional authentication failed. For more information please contact your local ICT-servicedesk and provide the details below.",
+  "ERROR_SAML_AuthnFailed": "The authentication with your additional authentication method failed. Please try again. For more information please contact your local ICT-servicedesk and provide the details below.",
+  "ERROR_SAML_NoAuthnContext": "There is no additional authentication method of the required strength available for your account. For more information please contact your local ICT servicedesk and provide the details below."
 }

--- a/src/SURFnet.Authentication.Adfs.Plugin/Resources/Labels.1043.json
+++ b/src/SURFnet.Authentication.Adfs.Plugin/Resources/Labels.1043.json
@@ -1,16 +1,16 @@
 {
-  "ERROR_0000": "Er is een onverwachte fout opgetreden. Neem contact op met uw eigen IT administrator en geef de volgende details door: ContextId '{0}', ActivityId '{1}'",
-  "ERROR_0001": "Verificatie mislukt. Neem contact op met uw eigen IT administrator en geef de volgende details door: ContextId '{0}', ActivityId '{1}'",
-  "ERROR_0002": "De StepUp configuratie is incorrect. Neem contact op met uw eigen IT administrator en geef de volgende details door: ContextId '{0}', ActivityId '{1}'",
-  "ERROR_0003": "Uw account in de Active Directory is niet geconfigureerd voor MFA. Neem contact op met uw eigen IT administrator en geef de volgende details door: ContextId '{0}', ActivityId '{1}'",
-  "AuthFailedFormTitle": "Authenticatie mislukt",
-  "SamlAuthFailedFormTitle": "Authenticatie mislukt",
-  "NoJavascript": "Je hebt Javascript uitgeschakeld. Schakele Javascript in om verder te gaan.",
+  "ERROR_0000": "Er is een onverwachte fout opgetreden. Neem contact op met de locale ICT-helpdesk en geeft de onderstaande gegevens door: ContextId '{0}', ActivityId '{1}'",
+  "ERROR_0001": "Aanvullende authenticatie mislukt. Neem contact op met de locale ICT-helpdesk en geeft de onderstaande gegevens door: ContextId '{0}', ActivityId '{1}'",
+  "ERROR_0002": "De configuratie van deze MFA extensie is niet correct. Neem contact op met de locale ICT-helpdesk en geeft de onderstaande gegevens door: ContextId '{0}', ActivityId '{1}'",
+  "ERROR_0003": "In dit account mist informatie die nodig is voor de aanvullende authenticatie. Neem contact op met de locale ICT-helpdesk en geeft de onderstaande gegevens door: ContextId '{0}', ActivityId '{1}'",
+  "AuthFailedFormTitle": "Aanvullende authenticatie mislukt",
+  "SamlAuthFailedFormTitle": "Aanvullende authenticatie mislukt",
+  "NoJavascript": "Javascript is uitgeschakeld. Schakel Javascript in om verder te gaan.",
   "OneMomentPlease": "Een moment geduld alstublieft...",
   "Working": "Bezig...",
-  "Description": "SURFNet Tweede Factor Authenticatie.",
-  "FriendlyName": "SURFNet Tweede Factor Authenticatie.",
-  "ERROR_SAML_Default": "Saml Fout. Verificatie mislukt. Neem contact op met uw eigen IT administrator en geef de onderstaande details door.",
-  "ERROR_SAML_AuthnFailed": "Saml AuthnFailed Fout. Verificatie mislukt. Neem contact op met uw eigen IT administrator en geef de onderstaande details door.",
-  "ERROR_SAML_NoAuthnContext": "Saml NoAuthnContext Fout. Verificatie mislukt. Neem contact op met uw eigen IT administrator en geef de onderstaande details door."
+  "Description": "SURF tweede factor authenticatie.",
+  "FriendlyName": "SURF tweede factor authenticatie.",
+  "ERROR_SAML_Default": "De aanvullende authenticatie is mislukt. Neem voor meer informatie contact op met de locale ICT-helpdesk en geeft de onderstaande gegevens door.",
+  "ERROR_SAML_AuthnFailed": "De authenticatie met de aanvullende authenticatie methode is mislukt. Probeer het op opnieuw. Neem voor meer informatie contact op met de locale ICT-helpdesk en geeft de onderstaande gegevens door.",
+  "ERROR_SAML_NoAuthnContext": "Er is voor dit account geen aanvullende authenticatie methode met de vereiste betrouwbaarheid beschikbaar. Neem voor meer informatie contact op met de locale ICT-helpdesk en geeft de onderstaande gegevens door."
 }

--- a/src/SURFnet.Authentication.Adfs.Plugin/Services/SamlService.cs
+++ b/src/SURFnet.Authentication.Adfs.Plugin/Services/SamlService.cs
@@ -30,6 +30,7 @@ namespace SURFnet.Authentication.Adfs.Plugin.Services
 
     using Models;
 using SURFnet.Authentication.Adfs.Plugin.NameIdConfiguration;
+    using SURFnet.Authentication.Adfs.Plugin.Setup.Common;
     using SURFnet.Authentication.Adfs.Plugin.Setup.Common.Exceptions;
 
     using Sustainsys.Saml2;
@@ -64,14 +65,14 @@ using SURFnet.Authentication.Adfs.Plugin.NameIdConfiguration;
             var samlConfiguration = Options.FromConfiguration;
             if (samlConfiguration == null)
             {
-                throw new InvalidConfigurationException("ERROR_0002", "The SAML configuration could not be loaded");
+                throw new InvalidConfigurationException(ErrorMessageValues.PluginConfigurationErrorResourceId, "The SAML configuration could not be loaded");
             }
 
             // Should have been tested in constructors!
             var spConfiguration = samlConfiguration.SPOptions;
             if (spConfiguration == null)
             {
-                throw new InvalidConfigurationException("ERROR_0002", "The service provider section of the SAML configuration could not be loaded");
+                throw new InvalidConfigurationException(ErrorMessageValues.PluginConfigurationErrorResourceId, "The service provider section of the SAML configuration could not be loaded");
             }
 
             var minimalLoa = StepUpConfig.Current.GetMinimalLoa(nameIDValue.UserName, nameIDValue.UserGroups, Log); 
@@ -134,12 +135,12 @@ using SURFnet.Authentication.Adfs.Plugin.NameIdConfiguration;
             var providers = serviceProviderConfiguration.IdentityProviders.KnownIdentityProviders.ToList();
             if (providers.Count == 0)
             {
-                throw new InvalidConfigurationException("ERROR_0002", "No identity providers found. Add the SURFConext identity provider before using Second Factor Authentication");
+                throw new InvalidConfigurationException(ErrorMessageValues.PluginConfigurationErrorResourceId, "No identity providers found. Add an SFO identity provider");
             }
 
             if (providers.Count > 1)
             {
-                throw new InvalidConfigurationException("ERROR_0002", "Too many identity providers found. Add only the SURFConext identity provider");
+                throw new InvalidConfigurationException(ErrorMessageValues.PluginConfigurationErrorResourceId, "Too many SAML identity providers found. Add only one SFO identity provider");
             }
 
             return providers[0];

--- a/src/SURFnet.Authentication.Adfs.Plugin/Setup/Common/ErrorMessageValues.cs
+++ b/src/SURFnet.Authentication.Adfs.Plugin/Setup/Common/ErrorMessageValues.cs
@@ -5,12 +5,20 @@
         /// <summary>
         /// The default error message resourcer identifier.
         /// </summary>
+        /// Message: An unexpected error occured. Please try again.
         public const string DefaultErrorMessageResourcerId = "ERROR_0000";
 
         /// <summary>
-        /// The default verification failed resourcer identifier.
+        /// The default authentication failed resourcer identifier.
         /// </summary>
+        /// Message: The additional authentication failed.
         public const string DefaultVerificationFailedResourcerId = "ERROR_0001";
+
+        /// <summary>
+        /// There is a configuration issue with the plugin itself
+        /// </summary>
+        /// Message: The configuration of this MFA extension is not correct
+        public const string PluginConfigurationErrorResourceId = "ERROR_0002";
 
         /// <summary>
         /// The default verification failed resourcer identifier.


### PR DESCRIPTION
Update the user facing error messages:
- Improve consistency
- Point users to their "ICT-servicedesk"
- Distinguish between the second factor authentication and the authentication with the windows account of the user. After some deliberation we settled on "additional authentication" / "additional authentication method"

Define constants for all messages in ErrorMessageValues and use them throughout the plugin code.
